### PR TITLE
Component view dashboard

### DIFF
--- a/client/src/components/PaginatedTable.tsx
+++ b/client/src/components/PaginatedTable.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react';
-// import { PaginationData, User } from './types';
 import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { icon } from '@fortawesome/fontawesome-svg-core/import.macro';
 
+import VulnerabilityViewRow from 'components/rows/VulnerabilityViewRow';
+import ComponentViewRow from 'components/rows/ComponentViewRow';
 import {
   View,
   ComponentViewColumn,
@@ -71,15 +71,25 @@ const PaginatedTable = ({
             </tr>
           </thead>
           <tbody>
-            {data.map((rowData: any, index: number) => {
-              return (
-                <tr key={index}>
-                  {shownColumns.map((column, index: number) => {
-                    return <td key={index}>{rowData[column]}</td>;
-                  })}
-                </tr>
-              );
-            })}
+            {view === View.Vulnerability
+              ? data.map((rowData: any, index: number) => {
+                  return (
+                    <VulnerabilityViewRow
+                      rowData={rowData}
+                      rowIndex={index}
+                      shownColumns={shownColumns}
+                    />
+                  );
+                })
+              : data.map((rowData: any, index: number) => {
+                  return (
+                    <ComponentViewRow
+                      rowData={rowData}
+                      rowIndex={index}
+                      shownColumns={shownColumns}
+                    />
+                  );
+                })}
           </tbody>
         </Table>
       </TableContainer>
@@ -129,16 +139,6 @@ const Table = styled.table`
     text-align: center;
     padding: 0.3rem;
     font-size: 0.7rem;
-  }
-  & tbody tr:nth-child(even) {
-    & td {
-      background: #fff;
-    }
-  }
-  & tbody tr:nth-child(odd) {
-    & td {
-      background: #ced0dc;
-    }
   }
 `;
 

--- a/client/src/components/rows/ComponentViewRow.tsx
+++ b/client/src/components/rows/ComponentViewRow.tsx
@@ -34,7 +34,7 @@ const ComponentViewRow = ({
           );
         })}
       </Row>
-      <tr >
+      <tr>
         <td colSpan={shownColumns.length}>
           {dropdownStatus && (
             <DropdownTable selected={dropdownStatus}>
@@ -46,9 +46,11 @@ const ComponentViewRow = ({
                 </tr>
               </thead>
               <tbody>
-                {shownColumns.map((data: string, index: number) => {
-                  return <td key={index}>{data}</td>;
-                })}
+                <tr>
+                  {shownColumns.map((data: string, index: number) => {
+                    return <td key={index}>{data}</td>;
+                  })}
+                </tr>
               </tbody>
             </DropdownTable>
           )}
@@ -84,14 +86,34 @@ const PlusButton = styled.button<DropdownProps>`
   }
 `;
 
-const DropdownTable = styled.div<DropdownProps>`
+// const DropdownRow = styled.tr<DropdownProps>`
+//   display: ${(props) => (props.selected ? 'block' : 'none')};
+// `;
+
+const DropdownTable = styled.table<DropdownProps>`
+  border-top: 10px solid ${(props) => props.theme.colors.primaryPink};
+  border-bottom: 10px solid ${(props) => props.theme.colors.primaryPink};
+  width: 90%;
+  margin-left: 10%;
   background-color: white;
-  padding: 5px 20px 10px 10px;
+  padding: 10px 0;
   height: auto;
   max-height: 350px;
   border-radius: 5px;
   box-shadow: 2px 2px 10px 2px #00000062;
-  /* display: ${(props) => (props.selected ? 'block' : 'none')}; */
+
+  & th {
+    color: ${(props) => props.theme.colors.minor};
+    position: sticky;
+    min-width: 90px;
+  }
+  tr {
+    width: 100%;
+  }
+  th + th,
+  td + td {
+    border-left: 2px dotted ${(props) => props.theme.colors.backgroundGrey};
+  }
 `;
 
 export default ComponentViewRow;

--- a/client/src/components/rows/ComponentViewRow.tsx
+++ b/client/src/components/rows/ComponentViewRow.tsx
@@ -86,10 +86,6 @@ const PlusButton = styled.button<DropdownProps>`
   }
 `;
 
-// const DropdownRow = styled.tr<DropdownProps>`
-//   display: ${(props) => (props.selected ? 'block' : 'none')};
-// `;
-
 const DropdownTable = styled.table<DropdownProps>`
   border-top: 10px solid ${(props) => props.theme.colors.primaryPink};
   border-bottom: 10px solid ${(props) => props.theme.colors.primaryPink};

--- a/client/src/components/rows/ComponentViewRow.tsx
+++ b/client/src/components/rows/ComponentViewRow.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+
+interface ComponentViewRowProps {
+  rowData: any;
+  rowIndex: number;
+  shownColumns: string[]; //VulnerabilityViewColumn[] | ComponentViewColumn[];
+}
+
+const ComponentViewRow = ({
+  rowData,
+  rowIndex,
+  shownColumns,
+}: ComponentViewRowProps) => {
+  const [dropdownStatus, setDropdownStatus] = useState<boolean>(false);
+  return (
+    <>
+      <Row even={0 === rowIndex % 2} key={rowIndex}>
+        {shownColumns.map((column, index: number) => {
+          return (
+            <td key={index}>
+              {index === 0 && (
+                <PlusButton
+                  selected={dropdownStatus}
+                  onClick={() => {
+                    setDropdownStatus(!dropdownStatus);
+                  }}
+                >
+                  +
+                </PlusButton>
+              )}
+              {rowData[column]}
+            </td>
+          );
+        })}
+      </Row>
+      <tr >
+        <td colSpan={shownColumns.length}>
+          {dropdownStatus && (
+            <DropdownTable selected={dropdownStatus}>
+              <thead>
+                <tr>
+                  {shownColumns.map((column: string, index: number) => {
+                    return <th key={index}>{column}</th>;
+                  })}
+                </tr>
+              </thead>
+              <tbody>
+                {shownColumns.map((data: string, index: number) => {
+                  return <td key={index}>{data}</td>;
+                })}
+              </tbody>
+            </DropdownTable>
+          )}
+        </td>
+      </tr>
+    </>
+  );
+};
+
+interface RowProps {
+  even: boolean;
+}
+
+const Row = styled.tr<RowProps>`
+  background-color: ${(props) => (props.even ? '#ced0dc' : '#eae7e7')};
+`;
+
+interface DropdownProps {
+  selected: boolean;
+}
+
+const PlusButton = styled.button<DropdownProps>`
+  float: left;
+  border: none;
+  border-radius: 100px;
+  color: white;
+  background-color: ${(props) =>
+    props.selected ? props.theme.colors.primaryPink : 'black'};
+  transform: 1s ease-in-out;
+  &:hover {
+    box-shadow: 0 0 3px 1px ${(props) => props.theme.colors.backgroundGrey};
+    background-color: ${(props) => props.theme.colors.backgroundGrey};
+  }
+`;
+
+const DropdownTable = styled.div<DropdownProps>`
+  background-color: white;
+  padding: 5px 20px 10px 10px;
+  height: auto;
+  max-height: 350px;
+  border-radius: 5px;
+  box-shadow: 2px 2px 10px 2px #00000062;
+  /* display: ${(props) => (props.selected ? 'block' : 'none')}; */
+`;
+
+export default ComponentViewRow;

--- a/client/src/components/rows/VulnerabilityViewRow.tsx
+++ b/client/src/components/rows/VulnerabilityViewRow.tsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+interface VulnerabilityViewRowProps {
+  rowData: any;
+  rowIndex: number;
+  shownColumns: string[]; //VulnerabilityViewColumn[] | ComponentViewColumn[];
+}
+
+const VulnerabilityViewRow = ({
+  rowData,
+  rowIndex,
+  shownColumns,
+}: VulnerabilityViewRowProps) => {
+  return (
+    <Row even={0 === rowIndex % 2} key={rowIndex}>
+      {shownColumns.map((column, index: number) => {
+        return <td key={index}>{rowData[column]}</td>;
+      })}
+    </Row>
+  );
+};
+
+interface RowProps {
+  even: boolean;
+}
+
+const Row = styled.tr<RowProps>`
+  background-color: ${(props) => (props.even ? '#ced0dc' : '#fff')};
+`;
+
+export default VulnerabilityViewRow;

--- a/client/src/helpers/enums/dashboard.ts
+++ b/client/src/helpers/enums/dashboard.ts
@@ -29,17 +29,13 @@ const ComponentViewColumnStrings = {
 enum VulnerabilityViewColumn { // Numbered so we can sort them if needed
   CVEID = 'CVEID', //{name: 'CVEID', string: 'CVE ID'},
   CVSSSeverity = 'CVSSSeverity',
-  Impact = 'Impact',
-  Likelihood = 'Likelihood',
   Risk = 'Risk',
   ComponentName = 'ComponentName',
 }
 
 const VulnerabilityViewColumnStrings = {
   CVEID: 'CVE ID',
-  CVSSSeverity: 'CVSSSeverity',
-  Impact: 'Impact',
-  Likelihood: 'Likelihood',
+  CVSSSeverity: 'CVSS Severity',
   Risk: 'Risk',
   ComponentName: 'Component Name',
 };

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -44,8 +44,6 @@ const Dashboard = () => {
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [shownColumns, setShownColumns] = useState<VulnerabilityViewColumn[]>([
     VulnerabilityViewColumn.CVEID,
-    VulnerabilityViewColumn.Impact,
-    VulnerabilityViewColumn.Likelihood,
     VulnerabilityViewColumn.ComponentName,
     VulnerabilityViewColumn.Risk,
   ]);


### PR DESCRIPTION
This PR solves issue #22.

## Changes: 
### Vulnerability view: 
- `dashboard.ts` and `Dashboads.tsx` - removed columns Impact and Likelihood based on feedback from a previous PR #10 
![Screen Shot 2023-01-29 at 10 42 10 AM](https://user-images.githubusercontent.com/44822892/215337675-b3599311-285e-42a3-a001-4ed9d15544ce.png)

### Component View:

- `PaginatedTable.tsx`
        - removed redundant imports
        - added 2 new components `VulnerabilityViewRow` and `ComponentViewRow` to represent the rows in each view
        - moved styling for each row into the aforementioned components


- `VulnerabilityViewRow` - contains the logic used to render table rows in the Vulnerability View

- `ComponentViewRow`
        - contains logic to render the component view row + dropdown for its list of vulnerabilities. 



#### Without dropdown:
![Screen Shot 2023-01-29 at 10 42 47 AM](https://user-images.githubusercontent.com/44822892/215337708-761335ca-40ce-42c8-a1f3-b3cc0b1caa3c.png)


#### With dropdown:
- **NOTE:** for right now, I have it that the dropdown just repeats the names of the columns. If I tried to mock the json for component view React crashed so I decided to just use the first mock for this POC. When data from the back end is integrated, this logic will be fixed. 
       - An issue has been created for this in #23 
![Screen Shot 2023-01-29 at 10 42 58 AM](https://user-images.githubusercontent.com/44822892/215337728-96f3a829-57d8-4be4-9b23-cdee99421f5f.png)


